### PR TITLE
reset any ROM that was patched by cheats when switching to hardcore

### DIFF
--- a/src/wx/retroachievements.cpp
+++ b/src/wx/retroachievements.cpp
@@ -106,11 +106,21 @@ static void ResetEmulator()
     // stop movie playback
     systemStopGamePlayback();
 
-    // disable cheats
+    // disabling the menu option prevents cheats from being evaluated each frame
     if (cheatsEnabled)
     {
         cheatsEnabled = false;
         mf->SetMenuOption("CheatsEnable", 0);
+    }
+
+    // pretend there aren't any cheats and call cheatsCheckKeys to reset any ROM
+    // that was patched by the previous call to cheatsCheckKeys.
+    if (cheatsNumber)
+    {
+        int oldCheatsNumber = cheatsNumber;
+        cheatsNumber = 0;
+        cheatsCheckKeys(0, 0);
+        cheatsNumber = oldCheatsNumber;
     }
 
     // reset frame rate


### PR DESCRIPTION
There's a small subset of cheats supported by VBA-M that actually modify the ROM data (instead of anything in the emulated memory). The modified ROM data was persisting through the transition to hardcore, and was not affected by disabling the per-frame evaluation of cheats.

Solution: when transitioning to hardcore, forcibly restore the ROM data that was modified.