### PR TITLE
circumvent mappers for memory exposure

### DIFF
--- a/src/wx/retroachievements.cpp
+++ b/src/wx/retroachievements.cpp
@@ -167,18 +167,24 @@ void RA_Init(HWND hWnd)
 
 extern uint8_t gbReadMemory(uint16_t address);
 extern void gbWriteMemory(uint16_t address, uint8_t value);
+extern uint8_t* gbMemoryMap[16];
 
 // GB/GBC Basic byte reader/writer
-static unsigned char ByteReader(unsigned int nOffs) { return gbReadMemory(nOffs); }
-static void ByteWriter(unsigned int nOffs, unsigned char nVal) { gbWriteMemory(nOffs, nVal); }
+static unsigned char ByteReader(unsigned int nOffs) { return gbMemoryMap[nOffs >> 12][nOffs & 0x0fff]; }
+static void ByteWriter(unsigned int nOffs, unsigned char nVal) { gbMemoryMap[nOffs >> 12][nOffs & 0x0fff] = nVal; }
 
-// GBC Byte reader/writer offset by the size of the map until the end of the work RAM
-static unsigned char PostRAMByteReader(unsigned int nOffs) { return gbReadMemory(nOffs + 0xE000); }
+// GB/GBC Byte reader/writer offset by the size of the map until the end of the work RAM
+static unsigned char PostRAMByteReader(unsigned int nOffs)
+{
+    if (nOffs >= 0x1F03 && nOffs <= 0x1F0E)
+    {
+        // prevents "Undocumented memory register read" message
+        if (nOffs == 0x1F03 || nOffs >= 0x1F08)
+            return 0xFF;
+    }
+    return gbReadMemory(nOffs + 0xE000);
+}
 static void PostRAMByteWriter(unsigned int nOffs, unsigned char nVal) { gbWriteMemory(nOffs + 0xE000, nVal); }
-
-// GBC RAM reader/writer targeting the first bank on work RAM
-static unsigned char GBCFirstRAMBankReader(unsigned int nOffs) { return gbWram ? gbWram[nOffs + 0x1000] : 0; }
-static void GBCFirstRAMBankWriter(unsigned int nOffs, unsigned char nVal) { if (gbWram) gbWram[nOffs + 0x1000] = nVal; }
 
 // GBC RAM reader/writer targeting work RAM banks 2-7
 static unsigned char GBCBankedRAMReader(unsigned int nOffs) { return gbWram ? gbWram[nOffs + 0x2000] : 0; }
@@ -200,7 +206,8 @@ void RA_OnLoadNewRom(ConsoleID nConsole, uint8_t* rom, size_t size, const char* 
     switch (nConsole)
     {
         case GB:
-            RA_InstallMemoryBank(0, ByteReader, ByteWriter, 0x10000);
+            RA_InstallMemoryBank(0, ByteReader, ByteWriter, 0xE000);               // Direct mapping ($0000-$DFFF)
+            RA_InstallMemoryBank(1, PostRAMByteReader, PostRAMByteWriter, 0x2000); // Echo RAM + controller registers ($E000-$FFFF)
             break;
 
         case GBC:
@@ -208,10 +215,9 @@ void RA_OnLoadNewRom(ConsoleID nConsole, uint8_t* rom, size_t size, const char* 
             // Bits 0-2 of $FF70 indicate which bank is currently accessible to the program in the $D000-$DFFF range.
             // Since that makes it hard to work with the memory in that region when building/running achievements, the memory exposed to
             // the achievements in $D000-$DFFF is always the first bank. The remaining banks are exposed in virtual memory above $10000.
-            RA_InstallMemoryBank(0, ByteReader, ByteWriter, 0xD000);                        // Direct mapping ($0000-$CFFF)
-            RA_InstallMemoryBank(1, GBCFirstRAMBankReader, GBCFirstRAMBankWriter, 0x1000);  // First bank ($D000-$DFFF)
-            RA_InstallMemoryBank(2, PostRAMByteReader, PostRAMByteWriter, 0x2000);          // Direct mapping ($E000-$FFFF)
-            RA_InstallMemoryBank(3, GBCBankedRAMReader, GBCBankedRAMWriter, 0x6000);        // RAM banks 2-7 ($10000-$15FFF)
+            RA_InstallMemoryBank(0, ByteReader, ByteWriter, 0xE000);                        // Direct mapping ($0000-$DFFF)
+            RA_InstallMemoryBank(1, PostRAMByteReader, PostRAMByteWriter, 0x2000);          // Echo RAM + controller registers ($E000-$FFFF)
+            RA_InstallMemoryBank(2, GBCBankedRAMReader, GBCBankedRAMWriter, 0x6000);        // RAM banks 2-7 ($10000-$15FFF)
             break;
 
         case GBA:


### PR DESCRIPTION
prevents undesirable flickering in $A000-$BFFF range as the mapper enables/disables I/O.